### PR TITLE
Code to transform .zst files into parquet

### DIFF
--- a/transform_parquet/analyze_slurm_jobs.py
+++ b/transform_parquet/analyze_slurm_jobs.py
@@ -1,0 +1,26 @@
+import os
+
+
+def get_slurm_job_report_as_str(file_path: str):
+    with open(file_path, 'r') as f:
+        return f.read()
+
+
+def analyze_slurm_jobs_reports(path: str = '/Users/andrea/Desktop/Temp/slurm_jobs/'):
+    files = os.listdir(path)
+    files = [f for f in files if f.endswith('.out')]
+    bad_files = []
+    for f in files:
+        s = get_slurm_job_report_as_str(file_path=f'{path}/{f}')
+        if 'Finished converting' not in s:
+            file = s.split('\n')[1].split(' ')[8].split('/')[-1]
+            print(file)
+            print(s)
+            bad_files.append(file)
+
+    print(sorted(bad_files))
+    print(sorted([b.split('.')[0] for b in bad_files]))
+
+
+if __name__ == '__main__':
+    analyze_slurm_jobs_reports()

--- a/transform_parquet/launch_script.py
+++ b/transform_parquet/launch_script.py
@@ -18,6 +18,7 @@ def launch_jobs(cluster: bool = True):
 
     file_names = extract_zst_file_names(folder_path=zst_folder_path)
     file_names = sorted(file_names)
+    file_names = ['RS_2022-01', 'RS_2022-02', 'RS_2022-03', 'RS_2022-04', 'RS_2022-05', 'RS_2022-06', 'RS_2022-07', 'RS_2022-08', 'RS_2022-09', 'RS_2022-10', 'RS_2022-11', 'RS_2022-12', 'RS_2023-01', 'RS_2023-02', 'RS_2023-03', 'RS_2023-04']
     print(file_names)
 
     os.system('chmod +x run_script.sh')

--- a/transform_parquet/launch_script.py
+++ b/transform_parquet/launch_script.py
@@ -17,7 +17,7 @@ def launch_jobs(cluster: bool = True):
         parquet_folder_path = '/Users/andrea/Desktop/PhD/Projects/Current/Reddit/data/parquet_test'
 
     file_names = extract_zst_file_names(folder_path=zst_folder_path)
-    file_names = sorted(file_names)[:-2]
+    file_names = sorted(file_names)
     print(file_names)
 
     os.system('chmod +x run_script.sh')

--- a/transform_parquet/launch_script.py
+++ b/transform_parquet/launch_script.py
@@ -1,0 +1,33 @@
+from typing import List
+import os
+
+
+def extract_zst_file_names(folder_path: str) -> List[str]:
+    file_names = os.listdir(folder_path)
+    file_names = [f.split('.')[0] for f in file_names if f.startswith('RS')]
+    return file_names
+
+
+def launch_jobs(cluster: bool = True):
+    if cluster:
+        zst_folder_path = '/cluster/work/coss/anmusso/reddit/submissions'
+        parquet_folder_path = '/cluster/work/coss/anmusso/reddit_parquet/submissions'
+    else:
+        zst_folder_path = '/Users/andrea/Desktop/PhD/Projects/Current/Reddit/data/comments'
+        parquet_folder_path = '/Users/andrea/Desktop/PhD/Projects/Current/Reddit/data/parquet_test'
+
+    file_names = extract_zst_file_names(folder_path=zst_folder_path)
+    file_names = sorted(file_names)[:-2]
+    print(file_names)
+
+    os.system('chmod +x run_script.sh')
+    for file_name in file_names:
+        if cluster:
+            os.system(f'sbatch run_script.sh {file_name} {zst_folder_path} {parquet_folder_path}')
+        else:
+            os.system(f'./run_script.sh {file_name} {zst_folder_path} {parquet_folder_path}')
+
+
+if __name__ == '__main__':
+    is_cluster = 'cluster' in os.getcwd()
+    launch_jobs(cluster=is_cluster)

--- a/transform_parquet/launch_script.py
+++ b/transform_parquet/launch_script.py
@@ -18,7 +18,6 @@ def launch_jobs(cluster: bool = True):
 
     file_names = extract_zst_file_names(folder_path=zst_folder_path)
     file_names = sorted(file_names)
-    file_names = ['RS_2022-01', 'RS_2022-02', 'RS_2022-03', 'RS_2022-04', 'RS_2022-05', 'RS_2022-06', 'RS_2022-07', 'RS_2022-08', 'RS_2022-09', 'RS_2022-10', 'RS_2022-11', 'RS_2022-12', 'RS_2023-01', 'RS_2023-02', 'RS_2023-03', 'RS_2023-04']
     print(file_names)
 
     os.system('chmod +x run_script.sh')

--- a/transform_parquet/run_script.py
+++ b/transform_parquet/run_script.py
@@ -1,0 +1,11 @@
+import sys
+from transform import zst_to_parquet
+
+if __name__ == '__main__':
+    file_name = sys.argv[1]
+    zst_folder_path = sys.argv[2]
+    parquet_folder_path = sys.argv[3]
+    zst_to_parquet(zst_file_path=f'{zst_folder_path}/{file_name}.zst',
+                   parquet_folder_path=parquet_folder_path,
+                   parquet_file_name=file_name)
+

--- a/transform_parquet/run_script.sh
+++ b/transform_parquet/run_script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#SBATCH --nodes=1
+#SBATCH --mem-per-cpu=5GB
+#SBATCH --time=01:30:00
+
+module load stack/2024-06 python/3.11.6
+source /cluster/home/anmusso/quantization/myenv/bin/activate
+
+python run_script.py "$@"

--- a/transform_parquet/run_script.sh
+++ b/transform_parquet/run_script.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #SBATCH --nodes=1
-#SBATCH --mem-per-cpu=5GB
-#SBATCH --time=01:30:00
+#SBATCH --mem-per-cpu=10GB
+#SBATCH --time=01:00:00
 
 module load stack/2024-06 python/3.11.6
 source /cluster/home/anmusso/quantization/myenv/bin/activate

--- a/transform_parquet/transform.py
+++ b/transform_parquet/transform.py
@@ -88,7 +88,6 @@ def _extract_line_data(line_str: str) -> Dict[str, Any]:
         'title': line_json['title'],
         'id': line_json['id'],
         'num_comments': line_json['num_comments'],
-        'upvote_ratio': line_json['upvote_ratio'],
         'selftext': line_json['selftext'],
         'media': line_json['media']
     }

--- a/transform_parquet/transform.py
+++ b/transform_parquet/transform.py
@@ -1,0 +1,94 @@
+from typing import Any, Dict, List, Tuple
+
+import json
+import logging
+import os
+import pandas as pd
+
+from zst_io import read_lines_zst
+
+logger = logging.getLogger('transform')
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch = logging.StreamHandler()
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+
+def zst_to_parquet(zst_file_path: str, parquet_folder_path: str, parquet_file_name: str):
+    logger.info(f'Converting {zst_file_path} to parquet files in {parquet_folder_path}')
+    file_size_zst_bytes = os.stat(zst_file_path).st_size
+
+    # Figure out how many parquet files to create
+    logger.info(f'Computing zst file lines')
+    n_lines_zst_file = _count_lines_zst(file_path=zst_file_path)
+    n_lines_parquet_file, n_parquet_files = _get_n_files_and_n_lines_parquet(lines_zst=n_lines_zst_file)
+    logger.info(f'Number of parquet files to create: {n_parquet_files}, { n_lines_parquet_file} lines per file')
+
+    bad_line_count = 0
+    file_lines = 0
+    parquet_file_id = 0
+
+    lines = []
+    for line, file_bytes_processed in read_lines_zst(file_name=zst_file_path):
+        try:
+            lines.append(_extract_line_data(line_str=line))
+        except (KeyError, json.JSONDecodeError) as err:
+            bad_line_count += 1
+
+        file_lines += 1
+
+        # Log progress
+        if file_lines % 100_000 == 0:
+            logger.info(f'FILE LINES: {file_lines} -- PERCENTAGE: {(file_bytes_processed / file_size_zst_bytes) * 100:.0f}% -- BAD LINES SHARE {bad_line_count / file_lines:.2f}, MEGABYTES: {file_bytes_processed / 1_000_000:.2f}')
+
+        # Save the parquet file
+        if file_lines % n_lines_parquet_file == 0 and parquet_file_id < n_parquet_files - 1:
+            logger.info(f'SAVING FILE: {parquet_file_id}')
+            _save_to_parquet_file(lines=lines, parquet_file_path=f'{parquet_folder_path}/{parquet_file_name}_{parquet_file_id}.parquet.snappy')
+            parquet_file_id += 1
+            del lines
+            lines = []
+
+    # Save the last parquet file
+    logger.info(f'TOTAL FILE LINES: {file_lines}')
+    logger.info(f'SAVING FILE: {parquet_file_id}')
+    _save_to_parquet_file(lines=lines, parquet_file_path=f'{parquet_folder_path}/{parquet_file_name}_{parquet_file_id}.parquet.snappy')
+    logger.info(f'Finished converting {zst_file_path} to parquet files in {parquet_folder_path}')
+
+
+def _count_lines_zst(file_path: str) -> int:
+    file_lines = 0
+    for _, _ in read_lines_zst(file_name=file_path):
+        file_lines += 1
+    return file_lines
+
+
+def _get_n_files_and_n_lines_parquet(lines_zst: int) -> Tuple[int, int]:
+    bytes_per_line_parquet = 170
+    desired_lines_parquet = (240 * 10**6) // bytes_per_line_parquet
+    n_files = max(1, lines_zst // desired_lines_parquet)
+    remainder = lines_zst % desired_lines_parquet
+    n_lines_parquet = desired_lines_parquet + remainder // n_files
+    return n_lines_parquet, n_files
+
+
+def _extract_line_data(line_str: str) -> Dict[str, Any]:
+    line_json = json.loads(line_str)
+    line = {
+        'author': line_json['author'],
+        'subreddit': line_json['subreddit'],
+        'score': line_json['score'],
+        'created_utc': line_json['created_utc'],
+        'title': line_json['title'],
+        'id': line_json['id'],
+        'num_comments': line_json['num_comments'],
+        'upvote_ratio': line_json['upvote_ratio'],
+        'selftext': line_json['selftext'],
+        'media': line_json['media']
+    }
+    return line
+
+
+def _save_to_parquet_file(lines: List[Dict[str, Any]], parquet_file_path: str):
+    pd.DataFrame(lines).to_parquet(parquet_file_path, engine='pyarrow', compression='snappy')

--- a/transform_parquet/transform.py
+++ b/transform_parquet/transform.py
@@ -66,10 +66,15 @@ def _count_lines_zst(file_path: str) -> int:
 
 def _get_n_files_and_n_lines_parquet(lines_zst: int) -> Tuple[int, int]:
     bytes_per_line_parquet = 170
-    desired_lines_parquet = (240 * 10**6) // bytes_per_line_parquet
+    desired_lines_parquet = (240 * 10 ** 6) // bytes_per_line_parquet
     n_files = max(1, lines_zst // desired_lines_parquet)
     remainder = lines_zst % desired_lines_parquet
-    n_lines_parquet = desired_lines_parquet + remainder // n_files
+
+    if remainder / (desired_lines_parquet * n_files) > 0.5:
+        n_files += 1
+        n_lines_parquet = desired_lines_parquet
+    else:
+        n_lines_parquet = desired_lines_parquet + remainder // n_files
     return n_lines_parquet, n_files
 
 

--- a/transform_parquet/transform.py
+++ b/transform_parquet/transform.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
-import json
 import logging
 import os
-import pandas as pd
+from pydantic import BaseModel, ValidationError
+import pyarrow as pa
+import pyarrow.parquet as pq
+import gc
 
 from zst_io import read_lines_zst
 
@@ -17,13 +19,9 @@ logger.addHandler(ch)
 
 def zst_to_parquet(zst_file_path: str, parquet_folder_path: str, parquet_file_name: str):
     logger.info(f'Converting {zst_file_path} to parquet files in {parquet_folder_path}')
-    file_size_zst_bytes = os.stat(zst_file_path).st_size
 
-    # Figure out how many parquet files to create
-    logger.info(f'Computing zst file lines')
-    n_lines_zst_file = _count_lines_zst(file_path=zst_file_path)
-    n_lines_parquet_file, n_parquet_files = _get_n_files_and_n_lines_parquet(lines_zst=n_lines_zst_file)
-    logger.info(f'Number of parquet files to create: {n_parquet_files}, { n_lines_parquet_file} lines per file')
+    file_size_zst_bytes = os.stat(zst_file_path).st_size
+    max_lines_parquet_file = 1_500_000
 
     bad_line_count = 0
     file_lines = 0
@@ -33,7 +31,7 @@ def zst_to_parquet(zst_file_path: str, parquet_folder_path: str, parquet_file_na
     for line, file_bytes_processed in read_lines_zst(file_name=zst_file_path):
         try:
             lines.append(_extract_line_data(line_str=line))
-        except (KeyError, json.JSONDecodeError) as err:
+        except ValidationError as err:
             bad_line_count += 1
 
         file_lines += 1
@@ -43,56 +41,59 @@ def zst_to_parquet(zst_file_path: str, parquet_folder_path: str, parquet_file_na
             logger.info(f'FILE LINES: {file_lines} -- PERCENTAGE: {(file_bytes_processed / file_size_zst_bytes) * 100:.0f}% -- BAD LINES SHARE {bad_line_count / file_lines:.2f}, MEGABYTES: {file_bytes_processed / 1_000_000:.2f}')
 
         # Save the parquet file
-        if file_lines % n_lines_parquet_file == 0 and parquet_file_id < n_parquet_files - 1:
+        if file_lines % max_lines_parquet_file == 0:
             logger.info(f'SAVING FILE: {parquet_file_id}')
             _save_to_parquet_file(lines=lines, parquet_file_path=f'{parquet_folder_path}/{parquet_file_name}_{parquet_file_id}.parquet.snappy')
             parquet_file_id += 1
             del lines
+            gc.collect()
             lines = []
 
     # Save the last parquet file
-    logger.info(f'TOTAL FILE LINES: {file_lines}')
     logger.info(f'SAVING FILE: {parquet_file_id}')
     _save_to_parquet_file(lines=lines, parquet_file_path=f'{parquet_folder_path}/{parquet_file_name}_{parquet_file_id}.parquet.snappy')
     logger.info(f'Finished converting {zst_file_path} to parquet files in {parquet_folder_path}')
 
 
-def _count_lines_zst(file_path: str) -> int:
-    file_lines = 0
-    for _, _ in read_lines_zst(file_name=file_path):
-        file_lines += 1
-    return file_lines
-
-
-def _get_n_files_and_n_lines_parquet(lines_zst: int) -> Tuple[int, int]:
-    bytes_per_line_parquet = 170
-    desired_lines_parquet = (240 * 10 ** 6) // bytes_per_line_parquet
-    n_files = max(1, lines_zst // desired_lines_parquet)
-    remainder = lines_zst % desired_lines_parquet
-
-    if remainder / (desired_lines_parquet * n_files) > 0.5:
-        n_files += 1
-        n_lines_parquet = desired_lines_parquet
-    else:
-        n_lines_parquet = desired_lines_parquet + remainder // n_files
-    return n_lines_parquet, n_files
+class RedditSubmission(BaseModel):
+    author: str | None
+    subreddit: str
+    score: int
+    created_utc: int
+    title: str
+    id: str
+    num_comments: int | None
+    selftext: str | None
+    media: Any | None
 
 
 def _extract_line_data(line_str: str) -> Dict[str, Any]:
-    line_json = json.loads(line_str)
-    line = {
-        'author': line_json['author'],
-        'subreddit': line_json['subreddit'],
-        'score': line_json['score'],
-        'created_utc': line_json['created_utc'],
-        'title': line_json['title'],
-        'id': line_json['id'],
-        'num_comments': line_json['num_comments'],
-        'selftext': line_json['selftext'],
-        'media': line_json['media']
+    reddit_submission = RedditSubmission.model_validate_json(line_str)
+    line_parse = {
+        'author': reddit_submission.author,
+        'subreddit': reddit_submission.subreddit,
+        'score': reddit_submission.score,
+        'created_utc': reddit_submission.created_utc,
+        'title': reddit_submission.title,
+        'id': reddit_submission.id,
+        'num_comments': reddit_submission.num_comments,
+        'selftext': reddit_submission.selftext,
+        'media': False if reddit_submission.media is None else True
     }
-    return line
+    return line_parse
 
 
-def _save_to_parquet_file(lines: List[Dict[str, Any]], parquet_file_path: str):
-    pd.DataFrame(lines).to_parquet(parquet_file_path, engine='pyarrow', compression='snappy')
+def _save_to_parquet_file(lines: List[Dict[str, Union[int, str, bool, None]]], parquet_file_path: str):
+    schema = pa.schema([
+        ('author', pa.string()),
+        ('subreddit', pa.string()),
+        ('score', pa.int64()),
+        ('created_utc', pa.int64()),
+        ('title', pa.string()),
+        ('id', pa.string()),
+        ('num_comments', pa.int64()),
+        ('selftext', pa.string()),
+        ('media', pa.bool_())
+    ])
+    table = pa.Table.from_pylist(lines, schema=schema)
+    pq.write_table(table, parquet_file_path)

--- a/transform_parquet/zst_io.py
+++ b/transform_parquet/zst_io.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import zstandard
+from typing import List
+
+
+def read_and_decode(reader: zstandard.ZstdDecompressionReader, chunk_size: int, max_window_size: int, previous_chunk=None, bytes_read: int = 0) -> str:
+    chunk = reader.read(chunk_size)
+    bytes_read += chunk_size
+    if previous_chunk is not None:
+        chunk = previous_chunk + chunk
+    try:
+        return chunk.decode()
+    # If we get a UnicodeDecodeError, it's likely because we have a character that's split between two chunks
+    # The simplest way to handle this is to read another chunk and append it to the previous one
+    except UnicodeDecodeError:
+        if bytes_read > max_window_size:
+            raise UnicodeError(f"Unable to decode frame after reading {bytes_read:,} bytes")
+        print(f"Decoding error with {bytes_read:,} bytes, reading another chunk")
+        return read_and_decode(reader, chunk_size, max_window_size, chunk, bytes_read)
+
+
+def read_lines_zst(file_name: str, reader_window_size: int = 2 ** 31, reader_chunk_size: int = 2 ** 27):
+    with open(file_name, 'rb') as file_handle:
+        buffer = ''
+        reader = zstandard.ZstdDecompressor(max_window_size=reader_window_size).stream_reader(file_handle)
+        # Loop through the entire file and read it in chunks
+        while True:
+            chunk = read_and_decode(reader=reader, chunk_size=reader_chunk_size, max_window_size=reader_window_size // 4)
+
+            if not chunk:
+                break
+            lines = (buffer + chunk).split("\n")
+
+            for line in lines[:-1]:
+                yield line, file_handle.tell()
+
+            buffer = lines[-1]
+
+        reader.close()
+
+
+


### PR DESCRIPTION
Files:
- launch_script.py
- run_script.py
- run_script.sh
- transform.py
- zst_io.py

The first three files (launch_script.py, run_script.py, run_script.sh) contain the logic to run many parallel jobs on the euler cluster. Specifically, launch_script.py is a short script that calls run_script.sh with different parameters. run_script.sh in turn calls run_script.py which executes the job. 

The file  transform.py contains the core logic of the transformation. Essentially, we read the zst file and progressively write it to different parquet files in batches of roughly 250 MB. 

The file zst_io.py contains the main logic to stream a zst file. 